### PR TITLE
Fix ambiguous timestamping

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ pip install -e .[examples]
 In the PC acting as the server:
 ```python
 from one_liner.server import RouterServer
-from threading import Event
+from time import sleep
 
 class Horn:
   def beep(self):
@@ -123,7 +123,7 @@ server = RouterServer(instances={"my_horn": my_horn})
 server.run()
 
 while True: # Nothing to do! Object control happens in another thread.
-    Event().wait() # or time.sleep(SHORT_DELAY)
+    time.sleep(0.001)
 ```
 
 In the PC acting as the client:
@@ -131,7 +131,7 @@ In the PC acting as the client:
 from one_liner.client import RouterClient
 
 client = RouterClient()
-result = client.call("my_horn", "beep") # call a func/method w/ args & kwargs; return the result.
+result = client.call("my_horn", "beep") # call method w/ args & kwargs; return the result.
 ```
 
 ### Streaming Data
@@ -152,7 +152,7 @@ server = RouterServer()
 server.add_stream_from_callable("live_video", # name of the stream
                                 30,  # How fast to call this function.
                                 get_frame) # function to call.
-server.run(run_in_thread=False)  # block, but we can not-block if set to True. That's it!
+server.run(block=True)  # if block=False, run in an internal thread. That's it!
 ```
 
 In the PC acting as the client:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "one_liner"
-version = "0.1.1.dev4"
+version = "0.1.1.dev5"
 
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/one_liner/client.py
+++ b/src/one_liner/client.py
@@ -60,8 +60,8 @@ class RouterClient:
                                              port=broadcast_port,
                                              context=self._context)
 
-    def call_by_name(self, call_name: str, args: list = None, kwargs: dict = None,
-                     get_timestamp: bool = False,
+    def call_by_name(self, call_name: str, args: list | None = None,
+                     kwargs: dict | None = None,
                      deserializer: Encoding | Callable = "pickle") \
             -> Any | Tuple[float, Any]:
 
@@ -82,25 +82,19 @@ class RouterClient:
             will overwrite existing pre-configured args setup with
             [`add_named_call`][one_liner.server.ZMQRPCServer.add_named_call]
             via a standard dict update.
-        get_timestamp :
-            If specified, return the data as a tuple where the first value is a
-            server-specified timestamp.
         deserializer :
             Callable function to deserialize the data or string-representation
             of one of the built-in options.
 
         Returns
         -------
-        object or tuple
-            The result of the call. If `get_timestamp` is true, returns a tuple
-            containing (server_timestamp, result).
+            The result of the call with a timestamp.
         """
         return self.rpc_client.call_by_name(call_name=call_name, args=args,
-                                            get_timestamp=get_timestamp,
                                             kwargs=kwargs, deserializer=deserializer)
 
     def call(self, obj_name: str, attr_name: str, args: list = None,
-             kwargs: dict = None, get_timestamp: bool = False,
+             kwargs: dict = None,
              deserializer: Encoding | Callable = "pickle") \
             -> Any | Tuple[float, Any]:
         """Call a function/method within the scope of the connected
@@ -116,9 +110,6 @@ class RouterClient:
             list of positional arguments for function call
         kwargs:
             dict of keyword arguments for function call
-        get_timestamp:
-            if specified, return the data as a tuple
-            where the first value is a server-specified timestamp.
         deserializer:
             callable function to deserialize the data or
             string-representation of one of the built-in options.
@@ -135,7 +126,6 @@ class RouterClient:
 
         """
         return self.rpc_client.call(obj_name, attr_name, args, kwargs,
-                                    get_timestamp=get_timestamp,
                                     deserializer=deserializer)
 
     def configure_stream(self, name: str,
@@ -255,7 +245,7 @@ class RouterClient:
     @property
     def server_version(self):
         """Return the server version."""
-        return self.rpc_client.call("__router_server", "get_version")
+        return self.rpc_client.call("__router_server", "get_version")[-1]
 
     def close(self):
         """Close the connection to the
@@ -277,33 +267,27 @@ class ZMQRPCClient:
         self.socket.connect(address)
 
     def call_by_name(self, call_name: str, args: list = None, kwargs: dict = None,
-                     get_timestamp: bool = False,
                      deserializer: Encoding | Callable = "pickle") \
             -> Any | Tuple[float, Any]:
         return self.call("__rpc_server", "_call_by_name",
                          args=[call_name], kwargs={"args": args, "kwargs": kwargs},
-                         get_timestamp=get_timestamp, deserializer=deserializer)
+                         deserializer=deserializer)
 
-    def call(self, obj_name: str, attr_name: str, args: list = None,
-             kwargs: dict = None, get_timestamp: bool = False,
-             deserializer: Encoding | Callable = "pickle") \
-        -> Any | Tuple[float, Any]:
+    def call(self, obj_name: str, attr_name: str, args: list | None = None,
+             kwargs: dict | None = None,
+             deserializer: Encoding | Callable = "pickle") -> Tuple[float, Any]:
         """Call a remote function available to the connected
         [`RouterServer`][one_liner.server.RouterServer] and return the result.
 
         """
         args = [] if args is None else args
         kwargs = {} if kwargs is None else kwargs
-        pickled_req = pickle.dumps((obj_name, attr_name, args, kwargs,
-                                    get_timestamp))
+        pickled_req = pickle.dumps((obj_name, attr_name, args, kwargs))
         self.socket.send(pickled_req, copy=False)
-        success, *reply = _recv(self.socket, has_timestamp=get_timestamp,
-                               deserializer=deserializer)
+        success, timestamp, data = _recv(self.socket, deserializer=deserializer)
         if not success:
-            raise RPCException(reply[-1]) # data contains exception string.
-        if get_timestamp:
-            return reply # (timestamp, data)
-        return reply[-1] # data
+            raise RPCException(data) # data contains exception string.
+        return timestamp, data
 
     def close(self):
         self.socket.close()
@@ -315,7 +299,7 @@ class ZMQStreamClient:
     __slots__ = ("log", "context", "address", "sub_sockets", "deserializers")
 
     def __init__(self, protocol: Protocol = "tcp", interface: str = "localhost",
-                 port: str = "5556", context: zmq.Context = None):
+                 port: str = "5556", context: zmq.Context | None = None):
         """
         """
         # Receive periodic broadcasted messages setup.
@@ -364,12 +348,12 @@ class ZMQStreamClient:
             if the underlying function raised an exception while being executed.
         """
         flag = 0 if block else zmq.NOBLOCK
-        success, timestamp, *data = _recv(self.sub_sockets[stream_name], flag=flag,
+        success, timestamp, data = _recv(self.sub_sockets[stream_name], flag=flag,
                                          prefix=stream_name,
                                          deserializer=self.deserializers[stream_name])
         if not success:
             raise StreamException(str(data))
-        return timestamp, *data
+        return timestamp, data
 
     def close(self):
         for name, socket in self.sub_sockets.items():

--- a/src/one_liner/rpc_server.py
+++ b/src/one_liner/rpc_server.py
@@ -113,7 +113,6 @@ class ZMQRPCServer:
         # Update args & kwargs from their defaults for this call if specified.
         args = args + default_args[len(args):]
         kwargs = default_kwargs | kwargs
-        print(f"updated call: {obj_name}.{attr_name}, args={args}, kwargs={kwargs}")
         return self._call(obj_name=obj_name, attr_name=attr_name, args=args,
                           kwargs=kwargs)
 

--- a/src/one_liner/rpc_server.py
+++ b/src/one_liner/rpc_server.py
@@ -52,19 +52,17 @@ class ZMQRPCServer:
             except zmq.Again:
                 continue
             request = pickle.loads(pickled_request)
-            obj_name, attr_name, args, kwargs, get_timestamp = request
+            obj_name, attr_name, args, kwargs = request
             try:
                 reply = self._call(obj_name=obj_name, attr_name=attr_name,
                                    args=args, kwargs=kwargs)
-                _send(self.socket, name="", data=reply, success=True,
-                      send_timestamp=get_timestamp)
+                _send(self.socket, name="", data=reply, success=True)
             except Exception as e:
-                _send(self.socket, name="", data=str(e), success=False,
-                      send_timestamp=get_timestamp)
+                _send(self.socket, name="", data=str(e), success=False)
 
     def add_named_call(self, call_name: str,
                              obj_name: str, attr_name: str,
-                             args: list = None, kwargs: list = None):
+                             args: list | None = None, kwargs: list | None = None):
         """Setup a call to be called with `call_by_name` on the
         :py:class:`~one_lner.client.ZMQRPCClient`
 
@@ -90,8 +88,8 @@ class ZMQRPCServer:
                        f"{', '.join([str(k)+'='+str(v) for k,v in kwargs.items()])})")
         self.named_call_signatures[call_name] = (obj_name, attr_name, args, kwargs)
 
-    def _call_by_name(self, call_name: str, args: list = None,
-                      kwargs: list = None):
+    def _call_by_name(self, call_name: str, args: list | None = None,
+                      kwargs: list | None = None):
         """Lookup a configured call by its `'call_name'`, call it with the
         specified args/kwargs, and return the result.
 
@@ -119,8 +117,8 @@ class ZMQRPCServer:
         return self._call(obj_name=obj_name, attr_name=attr_name, args=args,
                           kwargs=kwargs)
 
-    def _call(self, obj_name: str, attr_name: str, args: list = None,
-              kwargs: list = None):
+    def _call(self, obj_name: str, attr_name: str, args: list | None = None,
+              kwargs: list | None = None):
         """Call the object attribute with the specified args/kwargs and return
         the result."""
         args = [] if args is None else args

--- a/src/one_liner/utils.py
+++ b/src/one_liner/utils.py
@@ -27,7 +27,7 @@ DESERIALIZERS: dict[Encoding, Callable] = \
 
 
 def _send(socket: zmq.Context.socket, name: str, data: bytes | Any,
-          send_timestamp: bool = True, timestamp: float = None, success: bool = True,
+          timestamp: float = None, success: bool = True,
           serializer: Encoding | Callable = "pickle"):
     """Send the data on tne specified socket prefixed with the specified
     stream name. Used in both RPC and StreamServer
@@ -36,7 +36,6 @@ def _send(socket: zmq.Context.socket, name: str, data: bytes | Any,
     :param name: stream name. Under the hood, this is the topic.
     :param data: data to send. If the data is not `bytes`-like, the
        :paramref:`ZMQStreamServer._send.encoding` option cannot be None.
-    :param send_timestamp: if True, send a timestamp associated with the data.
     :param timestamp: if specified, send the data with a custom timestamp
        instead of the default ``time.perf_counter``.
     :param success: True if the data being sent was returned from a function
@@ -56,7 +55,7 @@ def _send(socket: zmq.Context.socket, name: str, data: bytes | Any,
     # It's a little clunky that we need to send the size of the pickled
     # metadata, but it prevents us from doing an extra copy into a
     # io.BytesIO object on the receiving end.
-    metadata = success if not send_timestamp else (success, timestamp)
+    metadata = (success, timestamp)
     metadata_bytes = pickle.dumps(metadata)
     metadata_num_bytes = len(metadata_bytes)
     serialize = SERIALIZERS.get(serializer, serializer)
@@ -68,12 +67,10 @@ def _send(socket: zmq.Context.socket, name: str, data: bytes | Any,
 
 
 def _recv(socket: zmq.Context.socket, flag: zmq.Flag = 0, prefix: str | None = None,
-          has_timestamp: bool = True, deserializer: Encoding | Callable = "pickle") -> (
-        Tuple[bool, Any] | Tuple[bool, float, Any]):
+          deserializer: Encoding | Callable = "pickle") -> Tuple[bool, float, Any]:
     """Receive data from a zmq socket and deserialize it.
 
     :param flag: additional zmq flag to pass to the socket
-    :param has_timestamp: if the
     :param prefix: a prefix to the data (usually a zmq topic) or `None` if unspecified.
     :param deserializer: the encoding option to decode the data, `None`
        if the data is `bytes`-like, or a user-supplied function to deserialize
@@ -85,14 +82,9 @@ def _recv(socket: zmq.Context.socket, flag: zmq.Flag = 0, prefix: str | None = N
     prefix_len = len(TOPIC_SUFFIX) if prefix is None else len(prefix) + len(TOPIC_SUFFIX)
     # Upack metadata first with pickle.
     metadata_num_bytes = struct.unpack("<H", raw_bytes[prefix_len:prefix_len + 2])[0]
-    # Unpack the timestamp if we know it came with the data.
-    if has_timestamp:
-        success, timestamp = pickle.loads(raw_bytes[prefix_len + 2:])
-        data = deserialize_fn(raw_bytes[prefix_len + 2 + metadata_num_bytes:])
-        return success, timestamp, data
-    success = pickle.loads(raw_bytes[prefix_len + 2:])
+    success, timestamp = pickle.loads(raw_bytes[prefix_len + 2:])
     data = deserialize_fn(raw_bytes[prefix_len + 2 + metadata_num_bytes:])
-    return success, data
+    return success, timestamp, data
 
 
 class RPCException(Exception):

--- a/tests/test_rpc_named_call.py
+++ b/tests/test_rpc_named_call.py
@@ -28,10 +28,10 @@ def test_many_client_receive():
     server.run()
 
     server.add_named_call("get_sensor0", "test_sensor_array", "get_data", args=[0])
-    data = client.call_by_name("get_sensor0")
+    _, data = client.call_by_name("get_sensor0") # omit timestamp
     assert 0 in data
     # Ensure we can override args.
-    data_from_sensor1 = client.call_by_name("get_sensor0", args=[1])
+    _, data_from_sensor1 = client.call_by_name("get_sensor0", args=[1])
     assert 1 in data_from_sensor1
     # Ensure this throws an exception: we already specified sensor_index as an arg.
     with pytest.raises(RPCException):

--- a/tests/test_zmq_broadcaster.py
+++ b/tests/test_zmq_broadcaster.py
@@ -31,13 +31,6 @@ def test_server_creation():
     server.close()
     # Debugging: show all open sockets
     ctx = zmq.Context.instance()
-    if hasattr(ctx, '_sockets'):
-        # Extract the actual socket objects from the weak references
-        open_sockets = [s for s in ctx._sockets if s is not None]
-        print(f"Context is waiting for {len(open_sockets)} socket(s):")
-        for s in open_sockets:
-            # Print socket type and its memory address for identification
-            print(f" - Socket Type: {s.socket_type}, Address: {hex(id(s))}")
     zmq.Context.instance().term()
 
 

--- a/tests/test_zmq_receiver.py
+++ b/tests/test_zmq_receiver.py
@@ -34,7 +34,7 @@ def test_request_and_reply():
     client = ZMQRPCClient()  # Create a server.
     server.run()
 
-    data = client.call("sensors", "get_data", args=[0])
+    _, data = client.call("sensors", "get_data", args=[0])
     try:
         assert 0 in data
         assert 0.0 <= data[0] <= 5.0


### PR DESCRIPTION
## Updates
This PR enforces all server replies to return a timestamp. Beforehand, it was optional as to whether you wanted to send the timestamp from the server, but the client needed to know if the timestamp was sent to be able to retrieve the data correctly. Because there was no way to know this, this pr just makes it so the timestamp is always sent with the data.

@micahwoodard I will make the needed adjustments to prototome-web-ui!


## Merge Checklist
* [x] bump the version
