### PR TITLE
Fix default args kwargs

### DIFF
--- a/src/one_liner/rpc_server.py
+++ b/src/one_liner/rpc_server.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import pickle
 from ftplib import error_reply
@@ -69,7 +70,8 @@ class ZMQRPCServer:
 
         obj_name, attr_name, args, kwargs = name_call
         func = getattr(self.instances[obj_name], attr_name)
-        params_schema, return_schema, description = get_func_sig_json_schema(func).values()
+        params_schema, return_schema, description = get_func_sig_json_schema(
+            func, default_args=args, default_kwargs=kwargs).values()
 
         return RPC(
             instance=obj_name,
@@ -140,9 +142,20 @@ class ZMQRPCServer:
             raise KeyError(f"'{call_name}' is not a named call.")
         obj_name, attr_name, default_args, default_kwargs = \
             self.named_call_signatures[call_name]
-        # Update args & kwargs from their defaults for this call if specified.
-        args = args + default_args[len(args):]
+        
+        try: 
+            func = getattr(self.instances[obj_name], attr_name)
+            parameter_names = list(inspect.signature(func).parameters.keys())
+        except (KeyError, AttributeError, TypeError, ValueError):
+            parameter_names = []
+
+        args = args + default_args[len(args):]  
         kwargs = default_kwargs | kwargs
+        # Remove any kwargs that are already in args by index
+        # args have higher priority than kwargs
+        for i in range(len(args)): 
+            if i < len(parameter_names) and parameter_names[i] in kwargs:
+                del kwargs[parameter_names[i]]  
         debug_msg = (f"Invoking named call: {obj_name}.{attr_name}("
                      f"{', '.join([str(a) for a in args])}"
                      f"{', ' if (len(args) and len(kwargs)) else ''}"

--- a/src/one_liner/utils.py
+++ b/src/one_liner/utils.py
@@ -89,7 +89,8 @@ def _recv(socket: zmq.Context.socket, flag: zmq.Flag = 0, prefix: str | None = N
     return success, timestamp, data
 
 
-def get_func_sig_json_schema(func: Callable) -> dict:
+def get_func_sig_json_schema(func: Callable, default_args: list = [], 
+                             default_kwargs: dict = {}) -> dict:
     """
     Get the JSON schema for the parameters and return type of a function as well 
     as the docstring description. 
@@ -105,12 +106,28 @@ def get_func_sig_json_schema(func: Callable) -> dict:
     # Parameters schema
     # -----------------
     signature = inspect.signature(func)
+    param_names = [n for n in signature.parameters.keys() if n != "self"]
+    # Get default values for parameters 
+    # <key: parameter name, value: default value>
+    default_param_values: dict[str, Any] = default_kwargs
+    for i, value in enumerate(default_args):
+        if i < len(param_names):
+            # args override kwargs if both are provided
+            default_param_values[param_names[i]] = value
     fields = {}
     for param_name, param in signature.parameters.items():
         if param_name == "self":
             continue
         annotation = param.annotation
-        default = param.default if param.default is not inspect.Parameter.empty else ...
+        if param_name in default_param_values:
+            # Default values from RouterServer 
+            default = default_param_values[param_name]
+        elif param.default is not inspect.Parameter.empty:
+            # Default values from function signature
+            default = param.default
+        else:
+            # No default
+            default = ...
         if annotation is inspect.Parameter.empty:
             fields[param_name] = (Any, Field(default, description="Type unspecified — provide a value."))
         else:

--- a/tests/test_func_sig_json_schema.py
+++ b/tests/test_func_sig_json_schema.py
@@ -152,3 +152,55 @@ def test_annotated_stream_yields_schema():
 
     server.close()
     client.close()
+
+
+################################################################################
+#
+#   DEFAULT ARGS / KWARGS TESTS
+#
+#   When add_named_call is given `args` and/or `kwargs`, the matching parameters
+#   should be optional in the generated JSON schema, with the default value as
+#   the schema `default`.
+#
+################################################################################
+
+
+@pytest.fixture
+def rpc_configs_with_defaults():
+    server = RouterServer(instances={"test_rpc": RPCClass()})
+    client = RouterClient()
+    server.run()
+    server.add_named_call("with_args", "test_rpc", "rpc_annotated", args=[10])
+    server.add_named_call(
+        "with_kwargs", "test_rpc", "rpc_annotated", kwargs={"input": 10}
+    )
+    server.add_named_call(
+        "with_both", "test_rpc", "rpc_annotated", args=[10], kwargs={"input": 11}
+    )
+    try:
+        _, data = client.get_rpc_configurations()
+        yield data
+    finally:
+        server.close()
+        client.close()
+
+
+def test_default_args_make_param_optional(rpc_configs_with_defaults):
+    """Check default value is set for parameter when args is provided in add_named_call"""
+    schema = rpc_configs_with_defaults["with_args"].params_schema
+    assert "input" not in schema.get("required", [])
+    assert schema["properties"]["input"]["default"] == 10
+
+
+def test_default_kwargs_make_param_optional(rpc_configs_with_defaults):
+    """Check default value is set for parameter when kwargs is provided in add_named_call"""
+    schema = rpc_configs_with_defaults["with_kwargs"].params_schema
+    assert "input" not in schema.get("required", [])
+    assert schema["properties"]["input"]["default"] == 10
+
+
+def test_default_args_override_default_kwargs(rpc_configs_with_defaults):
+    """When args and kwargs provided, use args as the default value"""
+    schema = rpc_configs_with_defaults["with_both"].params_schema
+    assert "input" not in schema.get("required", [])
+    assert schema["properties"]["input"]["default"] == 10

--- a/tests/test_rpc_named_call.py
+++ b/tests/test_rpc_named_call.py
@@ -39,3 +39,46 @@ def test_many_client_receive():
 
     server.close()
     client.close()
+
+
+def test_args_precedence_over_kwargs():
+    sensors = SensorArray()  # Create an object
+    server = RouterServer(instances={"test_sensor_array": sensors})  # Create a server.
+    client = RouterClient()
+    server.run()
+
+    server.add_named_call("get_sensor0", "test_sensor_array", "get_data", args=[0])
+    _, data = client.call_by_name("get_sensor0") # omit timestamp
+    assert 0 in data
+
+    # Ensure args has higher precedence than kwargs. The default arg is 0, but we specify 1 in kwargs.
+    _, data_from_sensor1 = client.call_by_name("get_sensor0", kwargs={"sensor_index": 1})
+    assert 0 in data_from_sensor1
+
+    server.close()
+    client.close()
+
+def test_client_precedence_over_default_args():
+    sensors = SensorArray()  # Create an object
+    server = RouterServer(instances={"test_sensor_array": sensors})  # Create a server.
+    client = RouterClient()
+    server.run()
+
+    server.add_named_call("get_sensor0", "test_sensor_array", "get_data", args=[0])
+    _, data = client.call_by_name("get_sensor0") # omit timestamp
+    assert 0 in data
+
+    # Ensure we can override args.
+    _, data_from_sensor1 = client.call_by_name("get_sensor0", args=[1])
+    assert 1 in data_from_sensor1
+
+    server.add_named_call("get_sensor0", "test_sensor_array", "get_data", kwargs={"sensor_index": 0})
+    _, data = client.call_by_name("get_sensor0") # omit timestamp
+    assert 0 in data
+
+    # Ensure we can override args.
+    _, data_from_sensor1 = client.call_by_name("get_sensor0", kwargs={"sensor_index": 1})
+    assert 1 in data_from_sensor1
+
+    server.close()
+    client.close()


### PR DESCRIPTION
## Updates

- Change behavior of how default ``args``/``kwargs`` from the server is handled with ``args``/``kwargs`` passed in from the client. 
- The following is how they're handled: 
    - args > kwargs precedence
    - RouterClient > RouterServer precedence
    - EX. if RouterClient passes in a kwarg, and RouterServer has a default args, default args will be used

## Fixed Issues

- Fixed issue where if default args is defined and RouterClient passes in a kwarg (for the same parameter), it will throw a Multi-value error. 

## Merge Checklist
* [ ] bump the version